### PR TITLE
Feat: Removed bastion ssh access for ssm connect

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ module "vpc" {
 ## Requirements
 |Name     |Version |
 |---------|--------|
-|terraform|>= 1.2.0|
-|aws      |~> 4.0  |
+|terraform|>= 1.7  |
+|aws      |~> 5    |
 
 
 ## Variables
@@ -36,8 +36,6 @@ module "vpc" {
 |nat_mode                  |string     |single_nat_instance|no      |Natgateway mode `single_nat_instance` or `ha_nat_gw`|
 |flowlogs_retention_in_days|number     |-1                 |no      |Retention in days for flowlogs|
 |bastion_security_groups   |set(string)|nil                |no      |Security group ID's for bastion|
-|trusted_ip_cidrs          |set(string)|nil                |no      |IP Ciders to trust on bastion host|
-|trusted_ssh_public_keys   |set(string)|nil                |no      |SSH keys to trust on bastion host|
 
 ### name_prefix:
 |Type        |Default|Required|Description|

--- a/bastion.tf
+++ b/bastion.tf
@@ -5,9 +5,23 @@ resource "aws_security_group" "bastion" {
   name        = "${local.name_prefix}bastion"
   vpc_id      = aws_vpc.this.id
 
+  egress {
+    description      = "Allow all egress traffic"
+    from_port        = 0
+    to_port          = 0
+    protocol         = "-1"
+    cidr_blocks      = ["0.0.0.0/0"]
+    ipv6_cidr_blocks = ["::/0"]
+  }
+
   tags = merge(local.default_tags, {
     Name = "${local.name_prefix}bastion"
   })
+}
+
+resource "aws_iam_role_policy_attachment" "bastion" {
+  role       = aws_iam_role.bastion[0].name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
 }
 
 resource "aws_iam_role" "bastion" {

--- a/main.tf
+++ b/main.tf
@@ -24,7 +24,7 @@ locals {
   ) : "${net.type}-${net.no}" => net }
 
   enable_nat_instance = var.nat.mode == "single_nat_instance" ? 1 : 0
-  enable_bastion      = length(var.bastion.trusted_ssh_public_keys) > 0 ? 1 : 0
+  enable_bastion      = var.bastion.enabled ? 1 : 0
 }
 
 data "aws_ami" "this" {
@@ -36,11 +36,6 @@ data "aws_ami" "this" {
     name   = "architecture"
     values = ["arm64"]
   }
-}
-
-data "aws_ip_ranges" "this" {
-  regions  = [local.region_name]
-  services = ["ec2_instance_connect"]
 }
 
 data "aws_iam_policy_document" "ec2_assume_role" {

--- a/nat_instance.tf
+++ b/nat_instance.tf
@@ -6,14 +6,6 @@ resource "aws_security_group" "nat_instance" {
   vpc_id      = aws_vpc.this.id
 
   ingress {
-    description = "Allow ingress SSH from ec2 instance connect."
-    from_port   = 22
-    to_port     = 22
-    protocol    = "tcp"
-    cidr_blocks = data.aws_ip_ranges.this.cidr_blocks
-  }
-
-  ingress {
     description = "Allow ingress traffic from the private subnet CIDR block"
     from_port   = 0
     to_port     = 0

--- a/output.tf
+++ b/output.tf
@@ -30,10 +30,6 @@ output "route_tables" {
   value = aws_route_table.this
 }
 
-output "bastion_public_ip" {
-  value = try(aws_eip.bastion[0].public_ip, null)
-}
-
 output "bastion_sg" {
   value = try(aws_security_group.bastion[0].id, null)
 }
@@ -44,8 +40,4 @@ output "kms_arn" {
 
 output "kms_alias" {
   value = aws_kms_alias.this.name
-}
-
-output "bastion_ssh_sg" {
-  value = try(aws_security_group.bastion_ssh[0].id, null)
 }

--- a/ssm_parameter.tf
+++ b/ssm_parameter.tf
@@ -1,9 +1,0 @@
-resource "aws_ssm_parameter" "bastion_ip" {
-  count = local.enable_bastion
-
-  name        = "/vpc/${local.name_prefix}vpc/bastion-ip"
-  description = "The Bastion public IP"
-  type        = "String"
-  value       = aws_eip.bastion[0].public_ip
-  tags        = local.default_tags
-}

--- a/userdata.sh
+++ b/userdata.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-
-sudo yum update -y
-
-%{ for ssh_key in ssh_keys ~}
-echo ${ssh_key} >> ~ec2-user/.ssh/authorized_keys
-%{ endfor ~}

--- a/userdata/bastion.sh
+++ b/userdata/bastion.sh
@@ -1,16 +1,4 @@
 #!/bin/bash
 
-# Add trusted ssh keys 
-%{ for ssh_key in ssh_keys ~}
-echo ${ssh_key} >> ~ec2-user/.ssh/authorized_keys
-%{ endfor ~}
-
 # Update packages
 yum update -y
-
-# Query network interface data
-TOKEN=$(curl -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600")
-INSTANCE_ID=$(curl -H "X-aws-ec2-metadata-token: $TOKEN" http://169.254.169.254/latest/meta-data/instance-id)
-
-# Associate EIP
-aws ec2 associate-address --instance-id $INSTANCE_ID --allocation-id ${eip} --allow-reassociation --region ${aws_region}

--- a/variables.tf
+++ b/variables.tf
@@ -34,10 +34,9 @@ variable "nat" {
 
 variable "bastion" {
   type = object({
-    type                    = optional(string, "t4g.nano")
-    security_groups         = optional(set(string), [])
-    trusted_ip_cidrs        = optional(set(string), [])
-    trusted_ssh_public_keys = optional(set(string), [])
+    enabled         = optional(bool, true)
+    type            = optional(string, "t4g.nano")
+    security_groups = optional(set(string), [])
   })
   default = {}
 }

--- a/version.tf
+++ b/version.tf
@@ -1,10 +1,10 @@
 terraform {
-  required_version = "~>1.7"
+  required_version = ">=1.7"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~>5.0"
+      version = "~>5"
     }
   }
 }


### PR DESCRIPTION
# Feature - Removed SSH access to bastion. Added SSM connect.

SSH access to bastion has been removed. Instead, ingress port 443 is now open for SSM access. 

README.md is updated