### PR TITLE
feat!: use launch templates instead of deprecated launch configurations

### DIFF
--- a/bastion.tf
+++ b/bastion.tf
@@ -88,9 +88,8 @@ resource "aws_autoscaling_group" "bastion" {
   desired_capacity          = 1
   max_size                  = 1
   min_size                  = 0
-  vpc_zone_identifier       = [aws_subnet.this["public-0"].id]
-  availability_zones        = data.aws_availability_zones.available.names
-  
+  vpc_zone_identifier       = [for k, v in local.subnet : aws_subnet.this[k].id if v.type == "public"]
+
   launch_template {
     id      = aws_launch_template.bastion[0].id
     version = "$Latest"

--- a/bastion.tf
+++ b/bastion.tf
@@ -89,6 +89,8 @@ resource "aws_autoscaling_group" "bastion" {
   max_size                  = 1
   min_size                  = 0
   vpc_zone_identifier       = [aws_subnet.this["public-0"].id]
+  availability_zones        = data.aws_availability_zones.available.names
+  
   launch_template {
     id      = aws_launch_template.bastion[0].id
     version = "$Latest"

--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,6 @@
 locals {
-  nat_instance_type       = "t4g.nano"
-  bastion_instance_type   = "t4g.nano"
+  nat_instance_type       = var.nat.type
+  bastion_instance_type   = var.bastion.type
   availability_zone_count = length(data.aws_availability_zones.available.names)
   vpc_cidr_bits           = tonumber(regex("/(\\d+)$", var.network.vpc_cidr)[0])
   pub_sub_cidr_bits       = var.network.public_subnet_bits - local.vpc_cidr_bits - [0, 1, 2, 2][local.availability_zone_count - 1]

--- a/nat_gateway.tf
+++ b/nat_gateway.tf
@@ -1,7 +1,7 @@
 resource "aws_eip" "nat_gw" {
   for_each = { for k, v in local.subnet : k => v if v.type == "public" && var.nat.mode == "ha_nat_gw" }
 
-  vpc = true
+  domain = "vpc"
 
   tags = merge(local.default_tags, {
     Name = "${local.name_prefix}natgw-ip-${each.value.no}"

--- a/nat_instance.tf
+++ b/nat_instance.tf
@@ -47,7 +47,8 @@ data "aws_iam_policy_document" "nat_instance_inline_policy" {
     actions = ["ec2:AttachNetworkInterface"]
     resources = [
       "arn:aws:ec2:${local.region_name}:${local.account_id}:instance/*",
-      "arn:aws:ec2:eu-central-1:381492064914:network-interface/${aws_network_interface.nat_instance[0].id}"
+      "arn:aws:ec2:eu-central-1:381492064914:network-interface/${aws_network_interface.nat_instance[0].id}",
+      aws_network_interface.nat_instance[0].arn
     ]
   }
 }

--- a/nat_instance.tf
+++ b/nat_instance.tf
@@ -151,9 +151,8 @@ resource "aws_autoscaling_group" "nat_instance" {
   desired_capacity          = 1
   max_size                  = 1
   min_size                  = 1
-  vpc_zone_identifier       = [aws_subnet.this["public-0"].id]
-  availability_zones        = data.aws_availability_zones.available.names
-  
+  vpc_zone_identifier       = [for k, v in local.subnet : aws_subnet.this[k].id if v.type == "public"]
+
   launch_template {
     id      = aws_launch_template.nat_instance[0].id
     version = "$Latest"

--- a/nat_instance.tf
+++ b/nat_instance.tf
@@ -76,7 +76,7 @@ resource "aws_network_interface" "nat_instance" {
   count = local.enable_nat_instance
 
   description       = "${local.name_prefix}nat-instance eni"
-  subnet_id         = aws_subnet.this["public-0"].id
+  subnet_id         = aws_subnet.this[var.nat.subnet].id
   security_groups   = [aws_security_group.nat_instance[0].id]
   source_dest_check = false
 
@@ -151,7 +151,7 @@ resource "aws_autoscaling_group" "nat_instance" {
   desired_capacity          = 1
   max_size                  = 1
   min_size                  = 1
-  vpc_zone_identifier       = [for k, v in local.subnet : aws_subnet.this[k].id if v.type == "public"]
+  vpc_zone_identifier       = [aws_subnet.this[var.nat.subnet].id]
 
   launch_template {
     id      = aws_launch_template.nat_instance[0].id

--- a/nat_instance.tf
+++ b/nat_instance.tf
@@ -152,6 +152,8 @@ resource "aws_autoscaling_group" "nat_instance" {
   max_size                  = 1
   min_size                  = 1
   vpc_zone_identifier       = [aws_subnet.this["public-0"].id]
+  availability_zones        = data.aws_availability_zones.available.names
+  
   launch_template {
     id      = aws_launch_template.nat_instance[0].id
     version = "$Latest"

--- a/variables.tf
+++ b/variables.tf
@@ -24,6 +24,7 @@ variable "nat" {
   type = object({
     mode = optional(string, "single_nat_instance")
     type = optional(string, "t4g.nano")
+    subnet = optional(string, "public-0")
   })
   default = {}
 

--- a/variables.tf
+++ b/variables.tf
@@ -23,6 +23,7 @@ variable "network" {
 variable "nat" {
   type = object({
     mode = optional(string, "single_nat_instance")
+    type = optional(string, "t4g.nano")
   })
   default = {}
 


### PR DESCRIPTION
- Update auto scaling groups to use launch templates instead of deprecated launch configurations
- allow for setting which subnet/az nat instance is deployed in (required because default subnet can lack instance capacity (e.g. "We currently do not have sufficient t4g.nano capacity in the Availability Zone you requested"))
- fix invalid iam permissions for nat instance to allow it to attach to network interface